### PR TITLE
fix bugs, issue: #95 #94

### DIFF
--- a/src/backend/booster/bk_dist/handler/ue4/cc/handler.go
+++ b/src/backend/booster/bk_dist/handler/ue4/cc/handler.go
@@ -407,7 +407,7 @@ func (cc *TaskCC) Includes(responseFile string, args []string, workdir string, f
 
 	// TOOD : maybe we should pass responseFile to calc md5, to ensure unique
 	var err error
-	cc.pumpHeadFile, err = getPumpIncludeFile(pumpdir, "pump_heads", ".txt", args)
+	cc.pumpHeadFile, err = getPumpIncludeFile(pumpdir, "pump_heads", ".txt", args, workdir)
 	if err != nil {
 		blog.Errorf("cc: do includes get output file failed: %v", err)
 		return nil, err

--- a/src/backend/booster/bk_dist/handler/ue4/cc/utils.go
+++ b/src/backend/booster/bk_dist/handler/ue4/cc/utils.go
@@ -1075,9 +1075,9 @@ func makeTmpFile(tmpDir, prefix, ext string) (string, error) {
 	return "", fmt.Errorf("cc: create tmp file failed: %s", target)
 }
 
-func getPumpIncludeFile(tmpDir, prefix, ext string, args []string) (string, error) {
+func getPumpIncludeFile(tmpDir, prefix, ext string, args []string, workdir string) (string, error) {
 	fullarg := strings.Join(args, " ")
-	md5str := md5.Sum([]byte(fullarg))
+	md5str := md5.Sum([]byte((fullarg + workdir)))
 	target := filepath.Join(tmpDir, fmt.Sprintf("%s_%x%s", prefix, md5str, ext))
 
 	return target, nil
@@ -1201,6 +1201,10 @@ func saveResultFile(rf *dcSDK.FileDesc, dir string) error {
 		return fmt.Errorf("file path is empty")
 	}
 
+	if !filepath.IsAbs(fp) {
+		fp = filepath.Join(dir, fp)
+	}
+
 	f, err := os.Create(fp)
 	if err != nil {
 		if !filepath.IsAbs(fp) && dir != "" {
@@ -1282,6 +1286,7 @@ func saveResultFile(rf *dcSDK.FileDesc, dir string) error {
 				blog.Errorf("cc: save file [%s] error: [%v]", fp, err)
 				return err
 			}
+			blog.Infof("cc: succeed save file %s size [%d]", fp, outlen)
 			break
 		default:
 			return fmt.Errorf("cc: unknown compress type [%s]", rf.Compresstype)

--- a/src/backend/booster/bk_dist/handler/ue4/cl/handler.go
+++ b/src/backend/booster/bk_dist/handler/ue4/cl/handler.go
@@ -523,7 +523,7 @@ func (cl *TaskCL) Includes(responseFile string, args []string, workdir string, f
 
 	// TOOD : maybe we should pass responseFile to calc md5, to ensure unique
 	var err error
-	cl.pumpHeadFile, err = getPumpIncludeFile(pumpdir, "pump_heads", ".txt", args)
+	cl.pumpHeadFile, err = getPumpIncludeFile(pumpdir, "pump_heads", ".txt", args, workdir)
 	if err != nil {
 		blog.Errorf("cl: do includes get output file failed: %v", err)
 		return nil, err
@@ -958,7 +958,7 @@ func (cl *TaskCL) postExecute(r *dcSDK.BKDistResult) error {
 		goto ERROREND
 	}
 
-	blog.Debugf("cl: output [%s] errormessage [%s]", r.Results[0].OutputMessage, r.Results[0].ErrorMessage)
+	blog.Infof("cl: output [%s] errormessage [%s]", r.Results[0].OutputMessage, r.Results[0].ErrorMessage)
 
 	if r.Results[0].RetCode == 0 {
 		blog.Infof("cl: success done post execute for: %v", cl.originArgs)

--- a/src/backend/booster/bk_dist/handler/ue4/cl/utils.go
+++ b/src/backend/booster/bk_dist/handler/ue4/cl/utils.go
@@ -806,9 +806,9 @@ func makeTmpFile(tmpDir, prefix, ext string) (string, error) {
 	return "", fmt.Errorf("cl: create tmp file failed: %s", target)
 }
 
-func getPumpIncludeFile(tmpDir, prefix, ext string, args []string) (string, error) {
+func getPumpIncludeFile(tmpDir, prefix, ext string, args []string, workdir string) (string, error) {
 	fullarg := strings.Join(args, " ")
-	md5str := md5.Sum([]byte(fullarg))
+	md5str := md5.Sum([]byte((fullarg + workdir)))
 	target := filepath.Join(tmpDir, fmt.Sprintf("%s_%x%s", prefix, md5str, ext))
 
 	return target, nil
@@ -919,6 +919,10 @@ func saveResultFile(rf *dcSDK.FileDesc, dir string) error {
 		return fmt.Errorf("file path is empty")
 	}
 
+	if !filepath.IsAbs(fp) {
+		fp = filepath.Join(dir, fp)
+	}
+
 	f, err := os.Create(fp)
 	if err != nil {
 		if !filepath.IsAbs(fp) && dir != "" {
@@ -1000,6 +1004,7 @@ func saveResultFile(rf *dcSDK.FileDesc, dir string) error {
 				blog.Errorf("cl: save file [%s] error: [%v]", fp, err)
 				return err
 			}
+			blog.Infof("cl: succeed save file %s size [%d]", fp, outlen)
 			break
 		default:
 			return fmt.Errorf("cl: unknown compress type [%s]", rf.Compresstype)


### PR DESCRIPTION
1. ue的cl和cc保存结果文件时，如果是相对路径，有可能保存到错误路径
2. pump根据md5查找缓存文件，有可能找错，需要调整md5的算法