### PR TITLE
fix: pump failed for cl-filter.exe, issue: #149

### DIFF
--- a/src/backend/booster/bk_dist/handler/ue4/clfilter/handler.go
+++ b/src/backend/booster/bk_dist/handler/ue4/clfilter/handler.go
@@ -126,7 +126,7 @@ func (cf *TaskCLFilter) RemoteRetryTimes() int {
 // OnRemoteFail give chance to try other way if failed to remote execute
 func (cf *TaskCLFilter) OnRemoteFail(command []string) (*dcSDK.BKDistCommand, error) {
 	if cf.clhandle != nil {
-		return cf.clhandle.OnRemoteFail(command)
+		return cf.clhandle.OnRemoteFail(cf.cldArgs)
 	}
 
 	return nil, nil


### PR DESCRIPTION
修正 pump失败时 cl-filter.exe 的参数问题