### PR TITLE
af参数发送失败问题修复

### DIFF
--- a/src/backend/booster/bk_dist/common/sdk/toolchain.go
+++ b/src/backend/booster/bk_dist/common/sdk/toolchain.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	dcFile "github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/file"
 	"github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/protocol"
@@ -250,4 +251,8 @@ func (t *Toolchain) ToFileDesc() ([]FileDesc, error) {
 	blog.Infof("toolchain: get all files:%v", toolfiles)
 
 	return toolfiles, nil
+}
+
+func GetAdditionFileKey() string {
+	return fmt.Sprintf("addition\\file|%d", time.Now().Unix())
 }

--- a/src/backend/booster/bk_dist/common/sdk/toolchain.go
+++ b/src/backend/booster/bk_dist/common/sdk/toolchain.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	dcFile "github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/file"
 	"github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/protocol"
@@ -254,5 +253,5 @@ func (t *Toolchain) ToFileDesc() ([]FileDesc, error) {
 }
 
 func GetAdditionFileKey() string {
-	return fmt.Sprintf("addition\\file|%d", time.Now().Unix())
+	return "addition\\file|key"
 }

--- a/src/backend/booster/bk_dist/controller/pkg/manager/basic/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/basic/mgr.go
@@ -443,6 +443,15 @@ func (m *Mgr) SetToolChain(toolchain *types.ToolChain) error {
 	return nil
 }
 
+// IsToolChainExsited return if toolchain files exsited
+func (m *Mgr) IsToolChainExsited(key string) bool {
+	m.toolchainLock.RLock()
+	defer m.toolchainLock.RUnlock()
+
+	_, ok := m.toolchainMap[key]
+	return ok
+}
+
 // GetToolChainFiles return the toolchain files
 func (m *Mgr) GetToolChainFiles(key string) ([]dcSDK.FileDesc, int64, error) {
 	m.toolchainLock.RLock()

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
@@ -516,6 +516,8 @@ func (m *Mgr) ExecuteTask(req *types.RemoteTaskExecuteRequest) (*types.RemoteTas
 	if err != nil {
 		blog.Errorf("remote: execute remote task for work(%s) from pid(%d) to server(%s), "+
 			"ensure files failed: %v", m.work.ID(), req.Pid, req.Server.Server, err)
+		req.BanWorkerList = append(req.BanWorkerList, req.Server)
+		blog.Errorf("remote: after add failed server(%s), banworkerlist is %v", req.Server, req.BanWorkerList)
 		return nil, err
 	}
 	if err = updateTaskRequestInputFilesReady(req, remoteDirs); err != nil {

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
@@ -514,10 +514,13 @@ func (m *Mgr) ExecuteTask(req *types.RemoteTaskExecuteRequest) (*types.RemoteTas
 
 	remoteDirs, err := m.ensureFilesWithPriority(handler, req.Pid, req.Sandbox, getFileDetailsFromExecuteRequest(req))
 	if err != nil {
-		blog.Errorf("remote: execute remote task for work(%s) from pid(%d) to server(%s), "+
-			"ensure files failed: %v", m.work.ID(), req.Pid, req.Server.Server, err)
 		req.BanWorkerList = append(req.BanWorkerList, req.Server)
-		blog.Errorf("remote: after add failed server(%s), banworkerlist is %v", req.Server, req.BanWorkerList)
+		var banlistStr string
+		for _, s := range req.BanWorkerList {
+			banlistStr = banlistStr + s.Server + ","
+		}
+		blog.Errorf("remote: execute remote task for work(%s) from pid(%d) to server(%s), "+
+			"ensure files failed: %v, after add failed server, banworkerlist is %s", m.work.ID(), req.Pid, req.Server.Server, err, banlistStr)
 		return nil, err
 	}
 	if err = updateTaskRequestInputFilesReady(req, remoteDirs); err != nil {

--- a/src/backend/booster/bk_dist/controller/pkg/types/interface.go
+++ b/src/backend/booster/bk_dist/controller/pkg/types/interface.go
@@ -242,6 +242,9 @@ type BasicMgr interface {
 	// update toolchain
 	SetToolChain(toolchain *ToolChain) error
 
+	//is tool exsited
+	IsToolChainExsited(key string) bool
+
 	// get toolchain files by key
 	GetToolChainFiles(key string) ([]dcSDK.FileDesc, int64, error)
 


### PR DESCRIPTION
bk-booster af目前无法保证在所有任务执行前都先发送到远端机器上，将af文件转化成工具链可以修复问题