### PR TITLE
feat: 增加toolchain发送失败后重试修复

### DIFF
--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
@@ -1268,6 +1268,7 @@ func (m *Mgr) sendToolchain(handler dcSDK.RemoteWorkerHandler, req *types.Remote
 	return nil
 }
 
+// getFailedFileCollectionByHost 返回文件集合，如果文件集没有全部完成，返回false，否则返回true
 func (m *Mgr) getFailedFileCollectionByHost(server string) ([]*types.FileCollectionInfo, bool, error) {
 	m.fileCollectionSendMutex.RLock()
 	defer m.fileCollectionSendMutex.RUnlock()
@@ -1279,7 +1280,7 @@ func (m *Mgr) getFailedFileCollectionByHost(server string) ([]*types.FileCollect
 	fcs := make([]*types.FileCollectionInfo, 0)
 	for _, re := range *target {
 		//如果有fc未到终结状态，则直接返回
-		if !re.SendStatus.IsTerminated() {
+		if !re.SendStatus.IsFinished() {
 			blog.Infof("remote: found file collection(%s) in file send cache, but not finished, status:%s", re.UniqID, re.SendStatus)
 			return nil, false, nil
 		}

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
@@ -1303,7 +1303,7 @@ func (m *Mgr) retrySendToolChain(handler dcSDK.RemoteWorkerHandler, req *types.R
 					return
 				}
 			}
-			m.resource.SetWorkerStatus(req.Server, Init)
+			m.resource.SetWorkerStatus(req.Server, RetryFailed)
 			blog.Errorf("remote: already retry to send tool chain for work(%s) for %d times from pid(%d) to server(%s) failed, keep worker disable", m.work.ID(), toolChainRetryTimes, req.Pid, req.Server.Server)
 		}(handler, *req)
 	} else {

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/slotbyworkeroffer.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/slotbyworkeroffer.go
@@ -257,6 +257,75 @@ func (wo *workerOffer) DisableWorker(host *dcProtocol.Host) {
 	return
 }
 
+func (wo *workerOffer) EnableWorker(host *dcProtocol.Host) {
+	if host == nil {
+		return
+	}
+	wo.workerLock.Lock()
+	defer wo.workerLock.Unlock()
+
+	for _, w := range wo.worker {
+		if !host.Equal(w.host) {
+			continue
+		}
+		if !w.disabled {
+			blog.Infof("remote slot: host:%v enabled before,do nothing now", *host)
+			return // already enabled
+		}
+
+		w.disabled = false
+		w.status = Init
+		wo.validWorkerNum += 1
+		break
+	}
+
+	blog.Infof("remote slot: total slot:%d after enable host:%v", wo.validWorkerNum, *host)
+}
+
+func (wo *workerOffer) CanWorkerRetry(host *dcProtocol.Host) bool {
+	if host == nil {
+		return false
+	}
+
+	wo.workerLock.Lock()
+	defer wo.workerLock.Unlock()
+
+	for _, wk := range wo.worker {
+		if !wk.host.Equal(host) {
+			continue
+		}
+
+		if wk.dead {
+			blog.Infof("remote slot: host:%v is already dead,do nothing now", host)
+			return false
+		}
+
+		if wk.status == Retrying {
+			blog.Infof("remote slot: host:%v is retrying,do nothing now", host)
+			return true
+		}
+		blog.Info("remote slot: host:%v can retry, change worker from %s to %s", host, wk.status, Retrying)
+		wk.status = Retrying
+		return false
+	}
+
+	return false
+}
+
+func (wo *workerOffer) SetWorkerStatus(host *dcProtocol.Host, s Status) {
+	wo.workerLock.Lock()
+	defer wo.workerLock.Unlock()
+
+	for _, w := range wo.worker {
+		if !host.Equal(w.host) {
+			continue
+		}
+
+		w.status = s
+		break
+	}
+}
+
 func (wo *workerOffer) WorkerDead(w *worker) {
 	if w == nil || w.host == nil {
 		return

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/worker.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/worker.go
@@ -30,6 +30,7 @@ const (
 	InService
 	Retrying
 	RetrySucceed
+	RetryFailed
 	Unknown = 99
 )
 
@@ -43,6 +44,7 @@ var (
 		InService:     "inservice",
 		Retrying:      "retrying",
 		RetrySucceed:  "retrysucceed",
+		RetryFailed:   "retryfailed",
 		Unknown:       "unknown",
 	}
 )

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/worker.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/worker.go
@@ -28,6 +28,8 @@ const (
 	DetectFailed
 	Refused
 	InService
+	Retrying
+	RetrySucceed
 	Unknown = 99
 )
 
@@ -39,6 +41,8 @@ var (
 		DetectFailed:  "detectfailed",
 		Refused:       "refused",
 		InService:     "inservice",
+		Retrying:      "retrying",
+		RetrySucceed:  "retrysucceed",
 		Unknown:       "unknown",
 	}
 )

--- a/src/backend/booster/bk_dist/controller/pkg/types/error.go
+++ b/src/backend/booster/bk_dist/controller/pkg/types/error.go
@@ -32,6 +32,7 @@ var (
 	ErrFileNotFound                 = fmt.Errorf("not found file info")
 	ErrWorkCannotBeUpdatedHeartbeat = fmt.Errorf("work can not be updated heartbeat")
 	ErrSendFileFailed               = fmt.Errorf("send file failed")
+	ErrSendFileRetrying             = fmt.Errorf("send file retrying")
 	ErrTaskCannotBeReleased         = fmt.Errorf("task can not be released")
 	ErrTaskAlreadyReleased          = fmt.Errorf("task already released")
 	ErrSlotsLockFailed              = fmt.Errorf("slots lock failed`")

--- a/src/backend/booster/bk_dist/controller/pkg/types/manager.go
+++ b/src/backend/booster/bk_dist/controller/pkg/types/manager.go
@@ -236,16 +236,18 @@ const (
 	FileSending
 	FileSendSucceed
 	FileSendFailed
+	FileSendRetrying
 	FileSendUnknown = 99
 )
 
 var (
 	fileStatusMap = map[FileSendStatus]string{
-		FileSendInit:    "sendinit",
-		FileSending:     "sending",
-		FileSendSucceed: "sendsucceed",
-		FileSendFailed:  "sendfailed",
-		FileSendUnknown: "unknown",
+		FileSendInit:     "sendinit",
+		FileSending:      "sending",
+		FileSendSucceed:  "sendsucceed",
+		FileSendFailed:   "sendfailed",
+		FileSendRetrying: "sendretrying",
+		FileSendUnknown:  "unknown",
 	}
 )
 

--- a/src/backend/booster/bk_dist/controller/pkg/types/manager.go
+++ b/src/backend/booster/bk_dist/controller/pkg/types/manager.go
@@ -260,6 +260,10 @@ func (f FileSendStatus) String() string {
 	return "unknown"
 }
 
+func (f FileSendStatus) IsTerminated() bool {
+	return f == FileSendSucceed || f == FileSendFailed
+}
+
 // FileCollectionInfo save file collection send status
 type FileCollectionInfo struct {
 	UniqID     string           `json:"uniq_id"`

--- a/src/backend/booster/bk_dist/controller/pkg/types/manager.go
+++ b/src/backend/booster/bk_dist/controller/pkg/types/manager.go
@@ -260,7 +260,7 @@ func (f FileSendStatus) String() string {
 	return "unknown"
 }
 
-func (f FileSendStatus) IsTerminated() bool {
+func (f FileSendStatus) IsFinished() bool {
 	return f == FileSendSucceed || f == FileSendFailed
 }
 


### PR DESCRIPTION
增加发送toolchain失败后重试，重试流程为：
发送失败后启动一个goroutine（保证一个worker一个goroutine），每隔10s轮询重试发送该worker上所有失败的filecollections，如果都重试成功worker置为enable，如果失败，最大重试次数10次，超过最大重试次数后不再重试发送，该worker保持disable