### PR TITLE
Dev tming

### DIFF
--- a/src/backend/booster/bk_dist/booster/command/command.go
+++ b/src/backend/booster/bk_dist/booster/command/command.go
@@ -473,6 +473,10 @@ var (
 			Name:  "clean_tmp_files_day_ago",
 			Usage: "clean tmp files which modify time before this days, default is 1",
 		},
+		commandCli.BoolFlag{
+			Name:  "ignore_http_status",
+			Usage: "tasks will be executed even local http connection disconnected when this flag set",
+		},
 	}
 )
 

--- a/src/backend/booster/bk_dist/booster/command/command.go
+++ b/src/backend/booster/bk_dist/booster/command/command.go
@@ -111,6 +111,7 @@ const (
 	FlagDynamicPort          = "dynamic_port"
 	FlagWorkerOfferSlot      = "worker_offer_slot"
 	FlagCleanTmpFilesDayAgo  = "clean_tmp_files_day_ago"
+	FlagIgnoreHttpStatus     = "ignore_http_status"
 
 	EnvBuildIDOld  = "TURBO_PLAN_BUILD_ID"
 	EnvBuildID     = "TBS_BUILD_ID"

--- a/src/backend/booster/bk_dist/booster/command/process.go
+++ b/src/backend/booster/bk_dist/booster/command/process.go
@@ -316,6 +316,7 @@ func newBooster(c *commandCli.Context) (*pkg.Booster, error) {
 			IdleKeepSecs:         c.Int(FlagIdleKeepSecs),
 			CleanTmpFilesDayAgo:  cleanTmpFilesDayAgo,
 			SearchToolchain:      c.Bool(FlagSearchToolchain),
+			IgnoreHttpStatus:     c.Bool(FlagIgnoreHttpStatus),
 		},
 
 		Transport: dcType.BoosterTransport{
@@ -323,7 +324,7 @@ func newBooster(c *commandCli.Context) (*pkg.Booster, error) {
 			ServerHost:             ServerHost,
 			Timeout:                5 * time.Second,
 			HeartBeatTick:          5 * time.Second,
-			InspectTaskTick:        100 * time.Millisecond,
+			InspectTaskTick:        1000 * time.Millisecond,
 			TaskPreparingTimeout:   time.Duration(waitResourceSeconds) * time.Second,
 			PrintTaskInfoEveryTime: 5,
 			CommitSuicideCheckTick: 5 * time.Second,

--- a/src/backend/booster/bk_dist/booster/pkg/booster.go
+++ b/src/backend/booster/bk_dist/booster/pkg/booster.go
@@ -364,6 +364,10 @@ func (b *Booster) getWorkersEnv() map[string]string {
 		requiredEnv[env.KeyExecutorSearchToolchain] = envValueTrue
 	}
 
+	if b.config.Works.IgnoreHttpStatus {
+		requiredEnv[env.KeyExecutorIgnoreHttpStatus] = envValueTrue
+	}
+
 	resultEnv := make(map[string]string, 10)
 	for k, v := range requiredEnv {
 		resultEnv[env.GetEnvKey(k)] = v

--- a/src/backend/booster/bk_dist/common/env/env.go
+++ b/src/backend/booster/bk_dist/common/env/env.go
@@ -75,6 +75,7 @@ const (
 	KeyExecutorUELibLocalCPUWeight     = "UE_LIB_LOCAL_CPU_WEIGHT"
 	KeyExecutorUELinkLocalCPUWeight    = "UE_LINK_LOCAL_CPU_WEIGHT"
 	KeyExecutorUEShaderLocalCPUWeight  = "UE_SHADER_LOCAL_CPU_WEIGHT"
+	KeyExecutorIgnoreHttpStatus        = "IGNORE_HTTP_STATUS"
 
 	KeyUserDefinedLogLevel         = "USER_DEFINED_LOG_LEVEL"
 	KeyUserDefinedExecutorLogLevel = "USER_DEFINED_EXECUTOR_LOG_LEVEL"

--- a/src/backend/booster/bk_dist/common/types/booster.go
+++ b/src/backend/booster/bk_dist/common/types/booster.go
@@ -133,7 +133,8 @@ type BoosterWorks struct {
 	EnableLink bool
 	EnableLib  bool
 
-	SearchToolchain bool
+	SearchToolchain  bool
+	IgnoreHttpStatus bool
 }
 
 // BoosterTransport describe the transport data to controller

--- a/src/backend/booster/bk_dist/controller/pkg/manager/local/executor.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/local/executor.go
@@ -361,7 +361,7 @@ func (e *executor) tryExecuteLocalTask() *types.LocalTaskExecuteResult {
 	defer e.mgr.work.Basic().UpdateJobStats(e.stats)
 
 	dcSDK.StatsTimeNow(&e.stats.LocalWorkEnterTime)
-	gotLock := true
+	gotLock := false
 	defer func() {
 		if gotLock {
 			dcSDK.StatsTimeNow(&e.stats.LocalWorkLeaveTime)
@@ -392,6 +392,8 @@ func (e *executor) tryExecuteLocalTask() *types.LocalTaskExecuteResult {
 		gotLock = false
 		blog.Infof("executor: not got lock to execute local-task from pid(%d) with weight %d", e.req.Pid, locallockweight)
 		return nil
+	} else {
+		gotLock = true
 	}
 
 	return e.realExecuteLocalTask(locallockweight)

--- a/src/backend/booster/bk_dist/controller/pkg/types/error.go
+++ b/src/backend/booster/bk_dist/controller/pkg/types/error.go
@@ -40,4 +40,5 @@ var (
 	ErrFileLock                     = fmt.Errorf("lock file failed")
 	ErrWorkIDEmpty                  = fmt.Errorf("work id is empty")
 	ErrWorkNotRead                  = fmt.Errorf("work is not ready")
+	ErrLocalHttpConnDisconnected    = fmt.Errorf("local http connection disconnected")
 )

--- a/src/backend/booster/bk_dist/controller/pkg/types/manager.go
+++ b/src/backend/booster/bk_dist/controller/pkg/types/manager.go
@@ -294,7 +294,7 @@ func (c *HttpConnCache) OnConnStatusError(key string) {
 }
 
 func (c *HttpConnCache) Check() {
-	blog.Infof("types: httpconncache: start go routine to check http conn status")
+	// blog.Infof("types: httpconncache: start go routine to check http conn status")
 
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
@@ -308,7 +308,7 @@ func (c *HttpConnCache) Check() {
 					old := v.ErrorStartTime.Add(time.Duration(v.delayCleanSecs) * time.Second)
 					if old.Before(time.Now()) {
 						delete(c.cache, k)
-						blog.Infof("types: httpconncache: deleted %s from cache after wait", k)
+						// blog.Infof("types: httpconncache: deleted %s from cache after wait", k)
 					}
 				}
 			}

--- a/src/backend/booster/bk_dist/controller/pkg/types/manager.go
+++ b/src/backend/booster/bk_dist/controller/pkg/types/manager.go
@@ -10,15 +10,23 @@
 package types
 
 import (
+	"fmt"
 	"os"
 	"os/user"
+	"strconv"
+	"strings"
+	"sync"
 	"time"
 
+	"github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/env"
 	dcProtocol "github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/protocol"
 	dcSDK "github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/sdk"
 	dcSyscall "github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/syscall"
+	"github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/websocket"
+	"github.com/TencentBlueKing/bk-turbo/src/backend/booster/common/blog"
 	"github.com/TencentBlueKing/bk-turbo/src/backend/booster/common/codec"
 	v2 "github.com/TencentBlueKing/bk-turbo/src/backend/booster/server/pkg/api/v2"
+	"github.com/emicklei/go-restful"
 )
 
 // WorkRegisterConfig describe the config of registering work
@@ -191,6 +199,9 @@ type RemoteTaskExecuteRequest struct {
 	Sandbox       *dcSyscall.Sandbox
 	IOTimeout     int
 	BanWorkerList []*dcProtocol.Host
+
+	HttpConnKey   string
+	HttpConnCache *HttpConnCache
 }
 
 // RemoteTaskExecuteResult describe the remote task execution result
@@ -212,6 +223,102 @@ type RemoteTaskSendFileResult struct {
 	Result *dcSDK.BKSendFileResult
 }
 
+// ++++++++++++++++ TODO : 增加http连接缓存
+func getHttpNetKey(req *restful.Request) string {
+	return fmt.Sprintf("%s_%d", req.Request.RemoteAddr, time.Now().Nanosecond())
+}
+
+type connStatus int
+
+const (
+	Connected connStatus = iota
+	Disconnected
+	Unknown = 99
+)
+
+type httpConn struct {
+	status         connStatus
+	delayCleanSecs int
+	ErrorStartTime time.Time
+}
+
+type HttpConnCache struct {
+	cache map[string]*httpConn
+	mutex sync.RWMutex
+}
+
+func NewHttpConnCache() *HttpConnCache {
+	return &HttpConnCache{
+		cache: make(map[string]*httpConn),
+	}
+}
+
+func (c *HttpConnCache) InsertOnce(key string, delayCleanSecs int) bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	_, ok := c.cache[key]
+	if !ok {
+		c.cache[key] = &httpConn{status: Connected, delayCleanSecs: delayCleanSecs}
+		return true
+	} else {
+		return false
+	}
+}
+
+func (c *HttpConnCache) IsConnStatusOk(key string) bool {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	v, ok := c.cache[key]
+	if !ok {
+		return false
+	}
+
+	return v.status == Connected
+}
+
+func (c *HttpConnCache) OnConnStatusError(key string) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	v, ok := c.cache[key]
+	if ok {
+		if v.delayCleanSecs == 0 {
+			delete(c.cache, key)
+		} else {
+			v.status = Disconnected
+			v.ErrorStartTime = time.Now()
+		}
+	}
+}
+
+func (c *HttpConnCache) Check() {
+	blog.Infof("types: httpconncache: start go routine to check http conn status")
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			c.mutex.Lock()
+			for k, v := range c.cache {
+				if v.status != Connected {
+					old := v.ErrorStartTime.Add(time.Duration(v.delayCleanSecs) * time.Second)
+					if old.Before(time.Now()) {
+						delete(c.cache, k)
+						blog.Infof("types: httpconncache: deleted %s from cache after wait", k)
+					}
+				}
+			}
+			c.mutex.Unlock()
+		}
+	}
+}
+
+// ----------------
+
 // LocalTaskExecuteRequest describe the local task execution param
 type LocalTaskExecuteRequest struct {
 	Pid          int
@@ -220,6 +327,116 @@ type LocalTaskExecuteRequest struct {
 	Commands     []string
 	Environments []string
 	Stats        *dcSDK.ControllerJobStats
+
+	// 该请求的执行是否依赖http连接状态，默认依赖，即ignoreHttpStatus为false;
+	// 如果依赖连接状态，当连接断开时，该请求直接返回失败
+	ignoreHttpStatus  bool
+	checkedHttpStatus bool
+	HttpConnKey       string
+	HttpConnCache     *HttpConnCache
+}
+
+// 这个正常只有一个协程调用，无需加锁
+func (r *LocalTaskExecuteRequest) InitHttpConnStatus(req *restful.Request,
+	cache *HttpConnCache,
+	s *websocket.Session,
+	delaysecs int) error {
+	shouldcheck := r.shouldCheckHttpStatus()
+	if shouldcheck && req != nil && cache != nil {
+		key := ""
+		if s == nil {
+			key = getHttpNetKey(req)
+		} else {
+			key = s.GetConnKey()
+		}
+
+		// TODO : 检查该连接的检查协程是否已启动
+		firstInsert := cache.InsertOnce(key, delaysecs)
+		if firstInsert {
+			blog.Infof("types: httpconncache: inserted %s to cache", key)
+
+			// 确保协程启动
+			var wg = sync.WaitGroup{}
+			wg.Add(1)
+			if s == nil {
+				go func(wg *sync.WaitGroup) {
+					wg.Done()
+					ctx := req.Request.Context()
+					select {
+					case <-ctx.Done():
+						err := ctx.Err()
+						cache.OnConnStatusError(key)
+						blog.Infof("types: httpconncache: found %s disconnected with error:%v", key, err)
+					}
+				}(&wg)
+			} else {
+				go func(wg *sync.WaitGroup) {
+					wg.Done()
+					ticker := time.NewTicker(3 * time.Second)
+					defer ticker.Stop()
+					for {
+						select {
+						case <-ticker.C:
+							if !s.IsValid() {
+								cache.OnConnStatusError(key)
+								blog.Infof("types: httpconncache: found websocket %s disconnected", key)
+								return
+							}
+						}
+					}
+				}(&wg)
+			}
+			wg.Wait()
+		}
+
+		r.HttpConnKey = key
+		r.HttpConnCache = cache
+		return nil
+	} else {
+		r.HttpConnKey = ""
+		r.HttpConnCache = nil
+		return nil
+	}
+}
+
+func IsHttpConnStatusOk(cache *HttpConnCache, key string) bool {
+	if cache == nil || key == "" {
+		return true
+	}
+
+	return cache.IsConnStatusOk(key)
+}
+
+func (r *LocalTaskExecuteRequest) shouldCheckHttpStatus() bool {
+	if r.checkedHttpStatus {
+		return !r.ignoreHttpStatus
+	}
+
+	// check env.KeyExecutorIgnoreHttpStatus
+	for _, e := range r.Environments {
+		if strings.HasPrefix(e, env.GetEnvKey(env.KeyExecutorIgnoreHttpStatus)) {
+			for i := 0; i < len(e); i++ {
+				if e[i] == '=' {
+					b, err1 := strconv.ParseBool(e[i+1:])
+					if err1 == nil {
+						r.ignoreHttpStatus = b
+						r.checkedHttpStatus = true
+						return !r.ignoreHttpStatus
+					} else {
+						r.ignoreHttpStatus = false
+						r.checkedHttpStatus = true
+						return !r.ignoreHttpStatus
+					}
+				}
+			}
+			break
+		}
+	}
+
+	r.ignoreHttpStatus = false
+	r.checkedHttpStatus = true
+
+	return !r.ignoreHttpStatus
 }
 
 // LocalTaskExecuteResult describe the local task execution result

--- a/src/backend/booster/bk_dist/shadertool/command/process.go
+++ b/src/backend/booster/bk_dist/shadertool/command/process.go
@@ -26,6 +26,7 @@ import (
 
 // mainProcess do the make process:
 func mainProcess(c *commandCli.Context) error {
+	common.FreshEnvFromProjectSetting()
 	initialLogDir(getLogDir(c.String(FlagLogDir)))
 	common.SetLogLevel(c.String(FlagLog))
 

--- a/src/backend/booster/bk_dist/ubttool/command/process.go
+++ b/src/backend/booster/bk_dist/ubttool/command/process.go
@@ -22,11 +22,13 @@ import (
 	"github.com/TencentBlueKing/bk-turbo/src/backend/booster/common/blog"
 	"github.com/TencentBlueKing/bk-turbo/src/backend/booster/common/conf"
 
+	shaderToolComm "github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/shadertool/common"
 	commandCli "github.com/urfave/cli"
 )
 
 // mainProcess do the make process:
 func mainProcess(c *commandCli.Context) error {
+	shaderToolComm.FreshEnvFromProjectSetting()
 	initialLogDir(getLogDir(c.String(FlagLogDir)))
 	setLogLevel(c.String(FlagLog))
 


### PR DESCRIPTION
避免无效的任务启动
websocket去掉一个context的判断（线上用户的日志显示似乎判断有误）
bk-booster检查controller的接口间隔从100毫秒改成1秒，减少误判概率
bk-ubt-tool和bk-shader-tool支持从配置文件中获取并刷新当前环境变量