### PR TITLE
fix: 修复windows ue编译命令过长问题

### DIFF
--- a/src/backend/booster/bk_dist/common/syscall/syscall_darwin.go
+++ b/src/backend/booster/bk_dist/common/syscall/syscall_darwin.go
@@ -124,7 +124,7 @@ func (s *Sandbox) ExecScriptsRaw(src string) (int, error) {
 	return 1, fmt.Errorf("not support")
 }
 
-func (s *Sandbox) ExecRawByFile(name string, arg ...string) (int, error) {
+func (s *Sandbox) ExecRawByFile(bt, name string, arg ...string) (int, error) {
 	return 1, fmt.Errorf("not support")
 }
 

--- a/src/backend/booster/bk_dist/common/syscall/syscall_unix.go
+++ b/src/backend/booster/bk_dist/common/syscall/syscall_unix.go
@@ -125,7 +125,7 @@ func (s *Sandbox) ExecScriptsRaw(src string) (int, error) {
 	return 1, fmt.Errorf("not support")
 }
 
-func (s *Sandbox) ExecRawByFile(name string, arg ...string) (int, error) {
+func (s *Sandbox) ExecRawByFile(bt, name string, arg ...string) (int, error) {
 	return 1, fmt.Errorf("not support")
 }
 

--- a/src/backend/booster/bk_dist/common/syscall/syscall_windows.go
+++ b/src/backend/booster/bk_dist/common/syscall/syscall_windows.go
@@ -178,20 +178,20 @@ func (s *Sandbox) ExecRawByFile(bt, name string, arg ...string) (int, error) {
 	fullArgs := strings.Join(arg, " ")
 	argsFile, err := os.CreateTemp(GetHandlerTmpDir(s, bt), "args-*.txt")
 	if err != nil {
-		blog.Errorf("sanbox: cmd too long and failed to create tmp file")
+		blog.Errorf("sanbox: exec raw script in file failed to create tmp file, error:%s", err.Error())
 		return -1, err
 	}
 	blog.Infof("sanbox:ready exec raw script in file %s with arg len %d", argsFile.Name(), len(arg))
 	err = os.WriteFile(argsFile.Name(), []byte(fullArgs), os.ModePerm)
 	if err != nil {
 		argsFile.Close() // 关闭文件
-		blog.Errorf("sanbox: cmd too long and failed to write tmp file %s", argsFile.Name())
+		blog.Errorf("sasanbox: exec raw script in file failed to write tmp file %s, error:%s", argsFile.Name(), err.Error())
 		return -1, err
 	}
 	argsFile.Close() // 关闭文件
 	code, err := s.execCommand(name, "@"+argsFile.Name())
 	if err != nil {
-		blog.Errorf("sanbox: cmd too long and failed to exec command [%s] %s in file (%s) ", name, fullArgs, argsFile.Name())
+		blog.Errorf("sanbox: exec raw script in file failed to exec command [%s] %s in file (%s) , error:%s", name, fullArgs, argsFile.Name(), err.Error())
 		return code, err
 	}
 	blog.Infof("sanbox: success to exec raw script in file %s, delete the arg file now", argsFile.Name())

--- a/src/backend/booster/bk_dist/common/syscall/syscall_windows.go
+++ b/src/backend/booster/bk_dist/common/syscall/syscall_windows.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -175,15 +174,15 @@ func (s *Sandbox) ExecScriptsRaw(src string) (int, error) {
 }
 
 // ExecCommand run the origin commands by file
-func (s *Sandbox) ExecRawByFile(name string, arg ...string) (int, error) {
+func (s *Sandbox) ExecRawByFile(bt, name string, arg ...string) (int, error) {
 	fullArgs := strings.Join(arg, " ")
-	argsFile, err := ioutil.TempFile(GetHandlerTmpDir(s), "args-*.txt")
+	argsFile, err := os.CreateTemp(GetHandlerTmpDir(s, bt), "args-*.txt")
 	if err != nil {
 		blog.Errorf("sanbox: cmd too long and failed to create tmp file")
 		return -1, err
 	}
-
-	err = ioutil.WriteFile(argsFile.Name(), []byte(fullArgs), os.ModePerm)
+	blog.Infof("sanbox:ready exec raw script in file %s with arg len %d", argsFile.Name(), len(arg))
+	err = os.WriteFile(argsFile.Name(), []byte(fullArgs), os.ModePerm)
 	if err != nil {
 		argsFile.Close() // 关闭文件
 		blog.Errorf("sanbox: cmd too long and failed to write tmp file %s", argsFile.Name())
@@ -193,12 +192,15 @@ func (s *Sandbox) ExecRawByFile(name string, arg ...string) (int, error) {
 	code, err := s.execCommand(name, "@"+argsFile.Name())
 	if err != nil {
 		blog.Errorf("sanbox: cmd too long and failed to exec command [%s] %s in file (%s) ", name, fullArgs, argsFile.Name())
+		return code, err
 	}
+	blog.Infof("sanbox: success to exec raw script in file %s, delete the arg file now", argsFile.Name())
+	os.Remove(argsFile.Name())
 	return code, err
 }
 
 // GetHandlerTmpDir get temp dir by booster type
-func GetHandlerTmpDir(sandBox *Sandbox) string {
+func GetHandlerTmpDir(sandBox *Sandbox, bt string) string {
 	var baseTmpDir string
 	if sandBox == nil {
 		baseTmpDir = os.TempDir()
@@ -209,7 +211,7 @@ func GetHandlerTmpDir(sandBox *Sandbox) string {
 	}
 
 	if baseTmpDir != "" {
-		fullTmpDir := path.Join(baseTmpDir, protocol.BKDistDir)
+		fullTmpDir := path.Join(baseTmpDir, protocol.BKDistDir, bt)
 		if !dcFile.Stat(fullTmpDir).Exist() {
 			if err := os.MkdirAll(fullTmpDir, os.ModePerm); err != nil {
 				blog.Warnf("common util: create tmp dir failed with error:%v", err)

--- a/src/backend/booster/bk_dist/controller/pkg/manager/local/executor.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/local/executor.go
@@ -349,7 +349,10 @@ func (e *executor) realExecuteLocalTask(locallockweight int32) *types.LocalTaskE
 		sandbox.Stderr = &errBuf
 		blog.Infof("executor: ready from pid(%d) run cmd:%v", e.req.Pid, e.req.Commands)
 		cmd := e.req.Commands[0]
-		if strings.HasSuffix(cmd, "cmd.exe") || strings.HasSuffix(cmd, "Cmd.exe") || strings.HasSuffix(cmd, "ispc.exe") || strings.HasSuffix(cmd, "Ispc.exe") {
+		if strings.HasSuffix(cmd, "cmd.exe") || strings.HasSuffix(cmd, "Cmd.exe") {
+			arg := strings.Join(e.req.Commands, " ")
+			code, err = sandbox.ExecScriptsRaw(arg)
+		} else if strings.HasSuffix(cmd, "ispc.exe") || strings.HasSuffix(cmd, "Ispc.exe") {
 			arg := strings.Join(e.req.Commands, " ")
 			if len(arg) > MaxWindowsCommandLength {
 				var bt string
@@ -361,9 +364,7 @@ func (e *executor) realExecuteLocalTask(locallockweight int32) *types.LocalTaskE
 				code, err = sandbox.ExecRawByFile(dcType.GetBoosterType(bt).String(), e.req.Commands[0], e.req.Commands[1:]...)
 			} else {
 				blog.Infof("executor: ready from pid(%d) run cmd in raw script with arg len %d", e.req.Pid, len(arg))
-				if !(strings.HasSuffix(cmd, "cmd.exe") || strings.HasSuffix(cmd, "Cmd.exe")) {
-					arg = "C:\\Windows\\system32\\cmd.exe /C \"" + arg + "\""
-				}
+				arg = "C:\\Windows\\system32\\cmd.exe /C \"" + arg + "\""
 				code, err = sandbox.ExecScriptsRaw(arg)
 			}
 		} else {

--- a/src/backend/booster/bk_dist/controller/pkg/manager/local/executor.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/local/executor.go
@@ -29,7 +29,7 @@ import (
 const (
 	ioTimeoutBuffer         = 50
 	retryAndSuccessLimit    = 3
-	MaxWindowsCommandLength = 30000
+	MaxWindowsCommandLength = 8000
 )
 
 func newExecutor(mgr *Mgr,
@@ -352,8 +352,15 @@ func (e *executor) realExecuteLocalTask(locallockweight int32) *types.LocalTaskE
 		if strings.HasSuffix(cmd, "cmd.exe") || strings.HasSuffix(cmd, "Cmd.exe") || strings.HasSuffix(cmd, "ispc.exe") || strings.HasSuffix(cmd, "Ispc.exe") {
 			arg := strings.Join(e.req.Commands, " ")
 			if len(arg) > MaxWindowsCommandLength {
-				code, err = sandbox.ExecRawByFile(e.req.Commands[0], e.req.Commands[1:]...)
+				var bt string
+				if sandbox == nil {
+					bt = env.GetEnv(env.BoosterType)
+				} else {
+					bt = sandbox.Env.GetEnv(env.BoosterType)
+				}
+				code, err = sandbox.ExecRawByFile(dcType.GetBoosterType(bt).String(), e.req.Commands[0], e.req.Commands[1:]...)
 			} else {
+				blog.Infof("executor: ready from pid(%d) run cmd in raw script with arg len %d", e.req.Pid, len(arg))
 				if !(strings.HasSuffix(cmd, "cmd.exe") || strings.HasSuffix(cmd, "Cmd.exe")) {
 					arg = "C:\\Windows\\system32\\cmd.exe /C \"" + arg + "\""
 				}

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
@@ -546,7 +546,9 @@ func (m *Mgr) callback4ResChanged() error {
 	if hl != nil && len(hl) > 0 {
 		m.setLastApplied(uint64(time.Now().Local().Unix()))
 		m.syncHostTimeNoWait(hl)
-		m.syncHostToken(hl) //get token to check if host not restarted
+		if runtime.GOOS != osDarwin { //mac not support
+			m.syncHostToken(hl) //get token to check if host not restarted
+		}
 	}
 
 	// if all workers released, we shoud clean the cache now


### PR DESCRIPTION
1、ispc.exe命令小于8000放在文件中执行
2、参数文件放入booster tmp目录，会定时清理
3、执行成功直接删除参数文件