### PR TITLE
修复windows ue编译命令过长问题

### DIFF
--- a/src/backend/booster/bk_dist/common/sdk/controller.go
+++ b/src/backend/booster/bk_dist/common/sdk/controller.go
@@ -54,10 +54,10 @@ type ControllerWorkSDK interface {
 type WorkJob interface {
 	ExecuteRemoteTask(req *BKDistCommand) (*BKDistResult, error)
 	// return http code / http message / execute result / execute error
-	ExecuteLocalTask(commands []string, workdir string) (int, string, *LocalTaskResult, error)
+	ExecuteLocalTask(commands []string, workdir string, commandType int) (int, string, *LocalTaskResult, error)
 	SendRemoteFile2All(req []FileDesc) error
 
-	ExecuteLocalTaskWithWebSocket(commands []string, workdir string) (int, string, *LocalTaskResult, error)
+	ExecuteLocalTaskWithWebSocket(commands []string, workdir string, commandType int) (int, string, *LocalTaskResult, error)
 }
 
 const (

--- a/src/backend/booster/bk_dist/common/syscall/syscall_darwin.go
+++ b/src/backend/booster/bk_dist/common/syscall/syscall_darwin.go
@@ -124,7 +124,7 @@ func (s *Sandbox) ExecScriptsRaw(src string) (int, error) {
 	return 1, fmt.Errorf("not support")
 }
 
-func (s *Sandbox) ExecRawByFile(name string, arg ...string) (int, error) {
+func (s *Sandbox) ExecRawByFile(bt, name string, arg ...string) (int, error) {
 	return 1, fmt.Errorf("not support")
 }
 

--- a/src/backend/booster/bk_dist/common/syscall/syscall_unix.go
+++ b/src/backend/booster/bk_dist/common/syscall/syscall_unix.go
@@ -125,7 +125,7 @@ func (s *Sandbox) ExecScriptsRaw(src string) (int, error) {
 	return 1, fmt.Errorf("not support")
 }
 
-func (s *Sandbox) ExecRawByFile(name string, arg ...string) (int, error) {
+func (s *Sandbox) ExecRawByFile(bt, name string, arg ...string) (int, error) {
 	return 1, fmt.Errorf("not support")
 }
 

--- a/src/backend/booster/bk_dist/common/syscall/syscall_windows.go
+++ b/src/backend/booster/bk_dist/common/syscall/syscall_windows.go
@@ -175,7 +175,7 @@ func (s *Sandbox) ExecScriptsRaw(src string) (int, error) {
 }
 
 // ExecCommand run the origin commands by file
-func (s *Sandbox) ExecRawByFile(name string, arg ...string) (int, error) {
+func (s *Sandbox) ExecRawByFile(bt, name string, arg ...string) (int, error) {
 	fullArgs := strings.Join(arg, " ")
 	argsFile, err := ioutil.TempFile(GetHandlerTmpDir(s), "args-*.txt")
 	if err != nil {

--- a/src/backend/booster/bk_dist/common/syscall/syscall_windows.go
+++ b/src/backend/booster/bk_dist/common/syscall/syscall_windows.go
@@ -178,20 +178,20 @@ func (s *Sandbox) ExecRawByFile(bt, name string, arg ...string) (int, error) {
 	fullArgs := strings.Join(arg, " ")
 	argsFile, err := os.CreateTemp(GetHandlerTmpDir(s, bt), "args-*.txt")
 	if err != nil {
-		blog.Errorf("sanbox: cmd too long and failed to create tmp file")
+		blog.Errorf("sanbox: exec raw script in file failed to create tmp file, error:%s", err.Error())
 		return -1, err
 	}
-	blog.Infof("sanbox:ready exec raw script in file %s with arg len %d", argsFile.Name(), len(fullArgs))
+	blog.Infof("sanbox:ready exec raw script in file %s with arg len %d", argsFile.Name(), len(arg))
 	err = os.WriteFile(argsFile.Name(), []byte(fullArgs), os.ModePerm)
 	if err != nil {
 		argsFile.Close() // 关闭文件
-		blog.Errorf("sanbox: cmd too long and failed to write tmp file %s", argsFile.Name())
+		blog.Errorf("sasanbox: exec raw script in file failed to write tmp file %s, error:%s", argsFile.Name(), err.Error())
 		return -1, err
 	}
 	argsFile.Close() // 关闭文件
 	code, err := s.execCommand(name, "@"+argsFile.Name())
 	if err != nil {
-		blog.Errorf("sanbox: cmd too long and failed to exec command [%s] %s in file (%s) ", name, fullArgs, argsFile.Name())
+		blog.Errorf("sanbox: exec raw script in file failed to exec command [%s] %s in file (%s) , error:%s", name, fullArgs, argsFile.Name(), err.Error())
 		return code, err
 	}
 	blog.Infof("sanbox: success to exec raw script in file %s, delete the arg file now", argsFile.Name())

--- a/src/backend/booster/bk_dist/common/types/executor.go
+++ b/src/backend/booster/bk_dist/common/types/executor.go
@@ -12,6 +12,12 @@ package types
 // BoosterType string
 type BoosterType string
 
+const (
+	MaxWindowsCommandLength = 30000
+	CommandDefault          = 0
+	CommandInFile           = 1
+)
+
 // define task types
 var (
 	BoosterCC      BoosterType = "cc"
@@ -24,7 +30,6 @@ var (
 	BoosterEcho    BoosterType = "echo"
 	BoosterCustom  BoosterType = "custom"
 	BoosterUnknown BoosterType = "unknown"
-
 )
 
 // String return the string of BoosterType
@@ -34,15 +39,15 @@ func (t BoosterType) String() string {
 
 var (
 	str2taskType = map[string]BoosterType{
-		BoosterCC.String():     BoosterCC,
-		BoosterFind.String():   BoosterFind,
-		BoosterTC.String():     BoosterTC,
-		BoosterCL.String():     BoosterCL,
-		BoosterShader.String(): BoosterShader,
-		BoosterUE4.String():    BoosterUE4,
-		BoosterClangCl.String() : BoosterClangCl,
-		BoosterEcho.String():   BoosterEcho,
-		BoosterCustom.String(): BoosterCustom,
+		BoosterCC.String():      BoosterCC,
+		BoosterFind.String():    BoosterFind,
+		BoosterTC.String():      BoosterTC,
+		BoosterCL.String():      BoosterCL,
+		BoosterShader.String():  BoosterShader,
+		BoosterUE4.String():     BoosterUE4,
+		BoosterClangCl.String(): BoosterClangCl,
+		BoosterEcho.String():    BoosterEcho,
+		BoosterCustom.String():  BoosterCustom,
 	}
 )
 

--- a/src/backend/booster/bk_dist/controller/pkg/api/v1/handler.go
+++ b/src/backend/booster/bk_dist/controller/pkg/api/v1/handler.go
@@ -907,6 +907,7 @@ func getLocalTaskExecuteRequest(req *restful.Request) (*types.LocalTaskExecuteRe
 		Commands:     param.Commands,
 		Environments: param.Environments,
 		Stats:        param.Stats,
+		CommandType:  param.CommandType,
 	}
 
 	if config.Stats == nil {

--- a/src/backend/booster/bk_dist/controller/pkg/api/v1/sdk.go
+++ b/src/backend/booster/bk_dist/controller/pkg/api/v1/sdk.go
@@ -935,7 +935,7 @@ func (wj *workJob) ExecuteRemoteTask(req *dcSDK.BKDistCommand) (*dcSDK.BKDistRes
 }
 
 // ExecuteLocalTask do the task in local controller
-func (wj *workJob) ExecuteLocalTask(commands []string, workdir string) (int, string, *dcSDK.LocalTaskResult, error) {
+func (wj *workJob) ExecuteLocalTask(commands []string, workdir string, commandType int) (int, string, *dcSDK.LocalTaskResult, error) {
 	var data []byte
 
 	dir := ""
@@ -964,6 +964,7 @@ func (wj *workJob) ExecuteLocalTask(commands []string, workdir string) (int, str
 		Environments: os.Environ(),
 		Stats:        wj.stats,
 		User:         *u,
+		CommandType:  commandType,
 	}, &data)
 
 	servercode := int(api.ServerErrOK)
@@ -988,7 +989,7 @@ func (wj *workJob) ExecuteLocalTask(commands []string, workdir string) (int, str
 }
 
 // ExecuteLocalTaskWithWebSocket do the task in local controller with websocket
-func (wj *workJob) ExecuteLocalTaskWithWebSocket(commands []string, workdir string) (int, string, *dcSDK.LocalTaskResult, error) {
+func (wj *workJob) ExecuteLocalTaskWithWebSocket(commands []string, workdir string, commandType int) (int, string, *dcSDK.LocalTaskResult, error) {
 	// 获取session
 	url := fmt.Sprintf(localExeWebSocketcURI, wj.sdk.id)
 	sp := websocket.GetGlobalSessionPool(wj.sdk.sdk.config.IP, int32(wj.sdk.sdk.config.Port), url, 10, nil)
@@ -1029,6 +1030,7 @@ func (wj *workJob) ExecuteLocalTaskWithWebSocket(commands []string, workdir stri
 		Environments: os.Environ(),
 		Stats:        wj.stats,
 		User:         *u,
+		CommandType:  commandType,
 	}, &data)
 
 	// 发送和接收结果

--- a/src/backend/booster/bk_dist/controller/pkg/api/v1/types.go
+++ b/src/backend/booster/bk_dist/controller/pkg/api/v1/types.go
@@ -188,6 +188,7 @@ type LocalTaskExecuteParam struct {
 	Environments []string                  `json:"environment"`
 	Stats        *dcSDK.ControllerJobStats `json:"stats"`
 	User         user.User                 `json:"user"`
+	CommandType  int                       `json:"command_type"`
 }
 
 // LocalTaskExecuteResp describe the response of doing local task execute to controller

--- a/src/backend/booster/bk_dist/controller/pkg/manager/local/executor.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/local/executor.go
@@ -27,9 +27,8 @@ import (
 )
 
 const (
-	ioTimeoutBuffer         = 50
-	retryAndSuccessLimit    = 3
-	MaxWindowsCommandLength = 30000
+	ioTimeoutBuffer      = 50
+	retryAndSuccessLimit = 3
 )
 
 func newExecutor(mgr *Mgr,
@@ -349,18 +348,23 @@ func (e *executor) realExecuteLocalTask(locallockweight int32) *types.LocalTaskE
 		sandbox.Stderr = &errBuf
 		blog.Infof("executor: ready from pid(%d) run cmd:%v", e.req.Pid, e.req.Commands)
 		cmd := e.req.Commands[0]
-		if strings.HasSuffix(cmd, "cmd.exe") || strings.HasSuffix(cmd, "Cmd.exe") || strings.HasSuffix(cmd, "ispc.exe") || strings.HasSuffix(cmd, "Ispc.exe") {
-			arg := strings.Join(e.req.Commands, " ")
-			if len(arg) > MaxWindowsCommandLength {
-				code, err = sandbox.ExecRawByFile(e.req.Commands[0], e.req.Commands[1:]...)
+		switch e.req.CommandType {
+		case dcType.CommandInFile: //try to run cmd in file
+			blog.Infof("executor: ready from pid(%d) run cmd in file ", e.req.Pid)
+			var bt string
+			if sandbox == nil {
+				bt = env.GetEnv(env.BoosterType)
 			} else {
-				if !(strings.HasSuffix(cmd, "cmd.exe") || strings.HasSuffix(cmd, "Cmd.exe")) {
-					arg = "C:\\Windows\\system32\\cmd.exe /C \"" + arg + "\""
-				}
-				code, err = sandbox.ExecScriptsRaw(arg)
+				bt = sandbox.Env.GetEnv(env.BoosterType)
 			}
-		} else {
-			code, err = sandbox.ExecCommand(e.req.Commands[0], e.req.Commands[1:]...)
+			code, err = sandbox.ExecRawByFile(dcType.GetBoosterType(bt).String(), e.req.Commands[0], e.req.Commands[1:]...)
+		default:
+			if strings.HasSuffix(cmd, "cmd.exe") || strings.HasSuffix(cmd, "Cmd.exe") {
+				arg := strings.Join(e.req.Commands, " ")
+				code, err = sandbox.ExecScriptsRaw(arg)
+			} else {
+				code, err = sandbox.ExecCommand(e.req.Commands[0], e.req.Commands[1:]...)
+			}
 		}
 		stdout, stderr = outBuf.Bytes(), errBuf.Bytes()
 	}

--- a/src/backend/booster/bk_dist/controller/pkg/manager/local/executor.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/local/executor.go
@@ -346,11 +346,11 @@ func (e *executor) realExecuteLocalTask(locallockweight int32) *types.LocalTaskE
 		var outBuf, errBuf bytes.Buffer
 		sandbox.Stdout = &outBuf
 		sandbox.Stderr = &errBuf
-		blog.Infof("executor: ready from pid(%d) run cmd:%v", e.req.Pid, e.req.Commands)
+		blog.Infof("executor: ready from pid(%d) run cmd:%v with command type:%d", e.req.Pid, e.req.Commands, e.req.CommandType)
 		cmd := e.req.Commands[0]
 		switch e.req.CommandType {
 		case dcType.CommandInFile: //try to run cmd in file
-			blog.Infof("executor: ready from pid(%d) run cmd in file ", e.req.Pid)
+			blog.Infof("executor: ready from pid(%d) run cmd in file with command type:%d", e.req.Pid, e.req.CommandType)
 			var bt string
 			if sandbox == nil {
 				bt = env.GetEnv(env.BoosterType)

--- a/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
+++ b/src/backend/booster/bk_dist/controller/pkg/manager/remote/mgr.go
@@ -546,7 +546,9 @@ func (m *Mgr) callback4ResChanged() error {
 	if hl != nil && len(hl) > 0 {
 		m.setLastApplied(uint64(time.Now().Local().Unix()))
 		m.syncHostTimeNoWait(hl)
-		m.syncHostToken(hl) //get token to check if host not restarted
+		if runtime.GOOS != osDarwin { //mac not support
+			m.syncHostToken(hl) //get token to check if host not restarted
+		}
 	}
 
 	// if all workers released, we shoud clean the cache now

--- a/src/backend/booster/bk_dist/controller/pkg/types/manager.go
+++ b/src/backend/booster/bk_dist/controller/pkg/types/manager.go
@@ -328,6 +328,7 @@ type LocalTaskExecuteRequest struct {
 	Commands     []string
 	Environments []string
 	Stats        *dcSDK.ControllerJobStats
+	CommandType  int
 
 	// 该请求的执行是否依赖http连接状态，默认依赖，即ignoreHttpStatus为false;
 	// 如果依赖连接状态，当连接断开时，该请求直接返回失败

--- a/src/backend/booster/bk_dist/executor/pkg/dist_executor.go
+++ b/src/backend/booster/bk_dist/executor/pkg/dist_executor.go
@@ -224,7 +224,7 @@ func (d *DistExecutor) runWork() (int, string, error) {
 		os.Args[1] = getAbsPath(os.Args[1])
 	}
 
-	retcode, retmsg, r, err := d.work.Job(d.stats).ExecuteLocalTask(os.Args[1:], "")
+	retcode, retmsg, r, err := d.work.Job(d.stats).ExecuteLocalTask(os.Args[1:], "", dcTypes.CommandDefault)
 	if err != nil || retcode != 0 {
 		if r != nil {
 			blog.Errorf("executor: execute failed, error: %v, ret code: %d,retmsg:%s,outmsg:%s,errmsg:%s,cmd:%v",

--- a/src/backend/booster/bk_dist/shadertool/pkg/executor.go
+++ b/src/backend/booster/bk_dist/shadertool/pkg/executor.go
@@ -86,9 +86,9 @@ func (d *Executor) runWork(fullargs []string, workdir string) (int, string, erro
 	var r *dcSDK.LocalTaskResult
 	var err error
 	if d.usewebsocket {
-		retcode, retmsg, r, err = d.work.Job(d.getStats(fullargs)).ExecuteLocalTaskWithWebSocket(fullargs, workdir)
+		retcode, retmsg, r, err = d.work.Job(d.getStats(fullargs)).ExecuteLocalTaskWithWebSocket(fullargs, workdir, dcTypes.CommandDefault)
 	} else {
-		retcode, retmsg, r, err = d.work.Job(d.getStats(fullargs)).ExecuteLocalTask(fullargs, workdir)
+		retcode, retmsg, r, err = d.work.Job(d.getStats(fullargs)).ExecuteLocalTask(fullargs, workdir, dcTypes.CommandDefault)
 	}
 
 	if err != nil || retcode != 0 {

--- a/src/backend/booster/bk_dist/ubttool/pkg/executor.go
+++ b/src/backend/booster/bk_dist/ubttool/pkg/executor.go
@@ -73,7 +73,7 @@ func (d *Executor) Update() {
 
 // Run main function entry
 func (d *Executor) Run(fullargs []string, workdir string, commandType int) (int, string, error) {
-	blog.Infof("ubtexecutor: command [%s] begins", strings.Join(fullargs, " "))
+	blog.Infof("ubtexecutor: command [%s] begins with command type:%d", strings.Join(fullargs, " "), commandType)
 	for i, v := range fullargs {
 		blog.Debugf("ubtexecutor: arg[%d] : [%s]", i, v)
 	}

--- a/src/backend/booster/bk_dist/ubttool/pkg/executor.go
+++ b/src/backend/booster/bk_dist/ubttool/pkg/executor.go
@@ -72,7 +72,7 @@ func (d *Executor) Update() {
 }
 
 // Run main function entry
-func (d *Executor) Run(fullargs []string, workdir string) (int, string, error) {
+func (d *Executor) Run(fullargs []string, workdir string, commandType int) (int, string, error) {
 	blog.Infof("ubtexecutor: command [%s] begins", strings.Join(fullargs, " "))
 	for i, v := range fullargs {
 		blog.Debugf("ubtexecutor: arg[%d] : [%s]", i, v)
@@ -80,10 +80,10 @@ func (d *Executor) Run(fullargs []string, workdir string) (int, string, error) {
 	defer blog.Infof("ubtexecutor: command [%s] finished", strings.Join(fullargs, " "))
 
 	// work available, run work with executor-progress
-	return d.runWork(fullargs, workdir)
+	return d.runWork(fullargs, workdir, commandType)
 }
 
-func (d *Executor) runWork(fullargs []string, workdir string) (int, string, error) {
+func (d *Executor) runWork(fullargs []string, workdir string, commandType int) (int, string, error) {
 	// d.initStats()
 
 	// ignore argv[0], it's itself
@@ -92,9 +92,9 @@ func (d *Executor) runWork(fullargs []string, workdir string) (int, string, erro
 	var r *dcSDK.LocalTaskResult
 	var err error
 	if d.usewebsocket {
-		retcode, retmsg, r, err = d.work.Job(d.getStats(fullargs)).ExecuteLocalTaskWithWebSocket(fullargs, workdir)
+		retcode, retmsg, r, err = d.work.Job(d.getStats(fullargs)).ExecuteLocalTaskWithWebSocket(fullargs, workdir, commandType)
 	} else {
-		retcode, retmsg, r, err = d.work.Job(d.getStats(fullargs)).ExecuteLocalTask(fullargs, workdir)
+		retcode, retmsg, r, err = d.work.Job(d.getStats(fullargs)).ExecuteLocalTask(fullargs, workdir, commandType)
 	}
 
 	if err != nil || retcode != 0 {

--- a/src/backend/booster/bk_dist/ubttool/pkg/ubttool.go
+++ b/src/backend/booster/bk_dist/ubttool/pkg/ubttool.go
@@ -24,7 +24,6 @@ import (
 	"github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/booster/pkg"
 	"github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/env"
 	dcFile "github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/file"
-	"github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/sdk"
 	dcSDK "github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/sdk"
 	dcType "github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/types"
 	dcUtil "github.com/TencentBlueKing/bk-turbo/src/backend/booster/bk_dist/common/util"
@@ -425,9 +424,13 @@ func (h *UBTTool) executeOneAction(action common.Action, actionchan chan common.
 
 	blog.Infof("UBTTool: raw cmd:[%s %s]", action.Cmd, action.Arg)
 
+	commandType := dcType.CommandDefault
 	fullargs := []string{action.Cmd}
-	if strings.HasSuffix(action.Cmd, "cmd.exe") || strings.HasSuffix(action.Cmd, "Cmd.exe") || strings.HasSuffix(action.Cmd, "ispc.exe") || strings.HasSuffix(action.Cmd, "Ispc.exe") {
+	if strings.HasSuffix(action.Cmd, "cmd.exe") || strings.HasSuffix(action.Cmd, "Cmd.exe") {
 		fullargs = append(fullargs, action.Arg)
+	} else if (strings.HasSuffix(action.Cmd, "ispc.exe") || strings.HasSuffix(action.Cmd, "Ispc.exe")) && len(action.Arg) > dcType.MaxWindowsCommandLength {
+		fullargs = append(fullargs, action.Arg)
+		commandType = dcType.CommandInFile
 	} else {
 		args, _ := shlex.Split(replaceWithNextExclude(action.Arg, '\\', "\\\\", []byte{'"'}))
 		fullargs = append(fullargs, args...)
@@ -442,7 +445,7 @@ func (h *UBTTool) executeOneAction(action common.Action, actionchan chan common.
 	waitsecs := 5
 	var err error
 	for try := 0; try < 3; try++ {
-		retcode, retmsg, err = h.executor.Run(fullargs, action.Workdir)
+		retcode, retmsg, err = h.executor.Run(fullargs, action.Workdir, commandType)
 		if retcode != int(api.ServerErrOK) {
 			blog.Warnf("UBTTool: failed to execute action with ret code:%d error [%+v] for %d times, actions:%+v", retcode, err, try+1, action)
 
@@ -724,7 +727,7 @@ func (h *UBTTool) newBooster() (*pkg.Booster, error) {
 		},
 
 		// got controller listen port from local file
-		Controller: sdk.ControllerConfig{
+		Controller: dcSDK.ControllerConfig{
 			NoLocal: false,
 			Scheme:  shaderToolComm.ControllerScheme,
 			IP:      shaderToolComm.ControllerIP,


### PR DESCRIPTION
1、ispc.exe命令大于30000放在文件中执行，其他命令维持原状
2、参数文件放入booster tmp目录，会定时清理
3、执行成功直接删除参数文件